### PR TITLE
fix: Update tools.php - PHP version check comparison error

### DIFF
--- a/public/tools.php
+++ b/public/tools.php
@@ -102,7 +102,7 @@ if (!empty($_POST)) {
                     // First check PHP version
                     $version_output = shell_exec($php_path.' -r "echo phpversion();"');
 
-                    if (version_compare($version_output, '7.1', '>=')) {
+                    if (version_compare($version_output, '7.1', '<')) {
                         $alerts[] = [
                             'type' => 'danger',
                             'text' => 'Incorrect PHP version (7.1+ is required):<br/><br/><pre>'.htmlspecialchars($version_output).'</pre>',


### PR DESCRIPTION
PHP Version check disallows all PHP versions unless before 7.1 due to >=

Correction to allow all PHP versions from 7.1 and after.

Ties into fix for https://github.com/freescout-helpdesk/freescout/issues/2901